### PR TITLE
common.make_new_tor_id() ’controller‘ referenced before assignment in the finally section.

### DIFF
--- a/common.py
+++ b/common.py
@@ -36,8 +36,8 @@ def error_log(target="", default=None, raise_err=False):
 @error_log()
 def make_new_tor_id():
     info("New Tor ID")
+    controller = Controller.from_port(port=9151)
     try:
-        controller = Controller.from_port(port=9151)
         controller.authenticate()
         controller.signal(Signal.NEWNYM)
         resp = requests.get(


### PR DESCRIPTION
’controller‘ referenced before assignment in the finally section,which result in an error in console:
[ make_new_tor_id]: local variable 'controller' referenced before assignment
